### PR TITLE
Enable interactive notebook elements

### DIFF
--- a/nbkickoff/__about__.py
+++ b/nbkickoff/__about__.py
@@ -1,5 +1,5 @@
 __title__ = 'nbkickoff'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __summary__ = 'Launch an IPython Notebook from a template notebook file'
 __url__ = 'https://github.com/lumicks/nbkickoff'
 

--- a/nbkickoff/nbkickoff.py
+++ b/nbkickoff/nbkickoff.py
@@ -12,6 +12,7 @@ CREATE_NEW_CONSOLE = 0x10
 
 from notebook import notebookapp
 from notebook.utils import url_path_join, url_escape
+from notebook.extensions import install_nbextension_python, enable_nbextension_python
 
 from .template import create_notebook_from_template
 
@@ -57,8 +58,17 @@ def open_notebook(notebook_file):
         logging.info("Starting new Jupyter server to serve notebook file")
         launch_detached_process(sys.executable, '-m', 'notebook', '--NotebookApp.open_browser=True', notebook_file)
 
+def enable_interactive():
+    """Enable notebook interactive widgets and plots"""
+    install_nbextension_python(module="ipympl", sys_prefix=True)
+    install_nbextension_python(module="widgetsnbextension", sys_prefix=True)
+
+    enable_nbextension_python(module="ipympl", sys_prefix=True)
+    enable_nbextension_python(module="widgetsnbextension", sys_prefix=True)
+
 
 def kickoff(template_file, target_file, variables):
+    enable_interactive()
     create_notebook_from_template(template_file, target_file, variables)
     open_notebook(target_file)
 


### PR DESCRIPTION
Install and enable `ipympl` and `widgetsnbextension` notebook extensions which allow using interactive elements in a notebook.

@onnodb this is required to spawn notebooks with functioning interactive elements, is a draft since I'd like now what you think, or if there is a better solution.